### PR TITLE
修改gridview、treeview默认背景为透明

### DIFF
--- a/script/ide/System/Windows/Controls/ScrollArea.lua
+++ b/script/ide/System/Windows/Controls/ScrollArea.lua
@@ -175,6 +175,12 @@ function ScrollArea:updateScrollGeometry()
 	end
 end
 
+function ScrollArea:ApplyCss(css)
+	if(self.viewport) then
+		self.viewport:ApplyCss(css);
+	end
+end
+
 function ScrollArea:paintEvent(painter)
 	self:updateScrollGeometry();
 --	painter:SetPen(self:GetBackgroundColor());

--- a/script/ide/System/Windows/mcml/Elements/pe_treeview.lua
+++ b/script/ide/System/Windows/mcml/Elements/pe_treeview.lua
@@ -40,6 +40,7 @@ local TreeView = commonlib.gettable("System.Windows.Controls.TreeView");
 local mcml = commonlib.gettable("System.Windows.mcml");
 
 local pe_treeview = commonlib.inherit(commonlib.gettable("System.Windows.mcml.Elements.pe_scrollarea"), commonlib.gettable("System.Windows.mcml.Elements.pe_treeview"));
+pe_treeview:Property({"class_name", "pe:treeview"});
 
 function pe_treeview:ctor()
 end
@@ -85,6 +86,19 @@ function pe_treeview:OnLoadComponentBeforeChild(parentElem, parentLayout, css)
 	if(css["overflow-y"] and css["overflow-y"] == "hidden") then
 		_this:setVerticalScrollBarPolicy("AlwaysOff");
 	end
+
+	if(not css.background and not css.background2) then
+		if(css["background-color"]) then
+			css.background = "Texture/whitedot.png";	
+		else
+			css["background-color"] = "#ffffff00";
+		end
+	end
+
+	if(self.control) then
+		self.control:ApplyCss(css);
+	end
+	
 
 
 	-- Extract from datasource if it is already provided in the input. 

--- a/script/ide/System/Windows/mcml/PageElement.lua
+++ b/script/ide/System/Windows/mcml/PageElement.lua
@@ -439,6 +439,7 @@ function PageElement:UpdateLayout(parentLayout)
 		local right, bottom = left+size_width, top+size_height
 		myLayout:SetUsedSize(right, bottom);
 		self:OnAfterChildLayout(myLayout, left+margin_left, top+margin_top, right-margin_right, bottom-margin_bottom);
+		width, height = myLayout:GetUsedSize();
 	end
 
 	if(bUseSpace) then


### PR DESCRIPTION
1.判断如果没有设置背景和背景色，则设置css的背景颜色为透明
2.这两个控件都通过  ScrollArea  实现，重载 ScrollArea 的 ApplyCss 方法，修改 viewport（视窗）的背景和背景色