### PR TITLE
1.<pe:input type="password"/> 显示内容修复，由明文为密文。

### DIFF
--- a/script/ide/System/Windows/Controls/EditBox.lua
+++ b/script/ide/System/Windows/Controls/EditBox.lua
@@ -412,6 +412,14 @@ function EditBox:focusOutEvent(event)
 	self:setCursorBlinkPeriod(0);
 end
 
+function EditBox:GetPasswordText()
+	local text = self:GetText();
+	if(self._page_element and self._page_element:isPasswordButton()) then	
+		text = string.rep("*",string.len(text))	
+	end
+	return text;
+end
+
 function EditBox:naturalTextWidth()
 	return self.m_text:GetWidth(self:GetFont());
 end
@@ -449,6 +457,7 @@ function EditBox:paintEvent(painter)
 	local textTop = lineRect:y();
 
 	local text = self:GetText();
+
 	if(hasTextClipping) then
 		-- obsoleted: we will clip the text in software, instead of doing hardware clipping. 
 		-- local endClipOfText = self.m_text:xToCursor(self.hscroll+lineRect:width()-1, nil, self:GetFont());
@@ -488,7 +497,7 @@ function EditBox:paintEvent(painter)
 		painter:SetFont(self:GetFont());
 		--painter:SetPen(self:GetColor());
 		local scale = self:GetScale();
-		painter:DrawTextScaled(self:x() + textLeft, self:y() + textTop, text, scale);
+		painter:DrawTextScaled(self:x() + textLeft, self:y() + textTop, self:GetPasswordText(), scale);
 	end
 
 	if(hasTextClipping) then

--- a/script/ide/System/Windows/mcml/Elements/pe_editbox.lua
+++ b/script/ide/System/Windows/mcml/Elements/pe_editbox.lua
@@ -32,6 +32,16 @@ function pe_editbox:OnLoadComponentBeforeChild(parentElem, parentLayout, css)
 	_this:Connect("textChanged", self, self.OnTextChanged)
 end
 
+
+function pe_editbox:isPasswordButton()
+	local type = self:GetAttributeWithCode("type", nil, true);
+	if(type == "password") then
+		return true;
+	end
+	return false;
+end
+
+
 function pe_editbox:OnLoadComponentAfterChild(parentElem, parentLayout, css)
 	local beFocus = self:GetBool("autofocus");
 	if(beFocus) then


### PR DESCRIPTION
script\ide\System\Windows\Controls\EditBox.lua
script\ide\System\Windows\mcml\Elements\pe_editbox.lua