### PR TITLE
add pe_editor css attr

### DIFF
--- a/script/kids/3DMapSystemApp/mcml/pe_editor.lua
+++ b/script/kids/3DMapSystemApp/mcml/pe_editor.lua
@@ -1423,6 +1423,29 @@ function pe_editor_text.create(rootName, mcmlNode, bindingContext, _parent, left
 			local font = string.format("%s;%d;%s", font_family, font_size, font_weight);
 			_this.font = font;
 		end
+
+		local alignFormat = 0;
+		if(css["text-align"]) then
+			if(css["text-align"] == "right") then
+				alignFormat = 2;
+			elseif(css["text-align"] == "left") then
+				alignFormat = 0;
+			end
+		end
+		if(css["text-singleline"] ~= "false") then
+			alignFormat = alignFormat + 32;
+		else
+			if(css["text-wordbreak"] == "true") then
+				alignFormat = alignFormat + 16;
+			end
+		end
+		if(css["text-noclip"] ~= "false") then
+			alignFormat = alignFormat + 256;
+		end
+		if(css["text-valign"] ~= "top") then
+			alignFormat = alignFormat + 4;
+		end
+		_guihelper.SetUIFontFormat(_this, alignFormat);
 		
 		local empty_text = mcmlNode:GetAttributeWithCode("EmptyText");
 		if(empty_text and empty_text~="") then


### PR DESCRIPTION
由于input不能垂直居中等属性，因此新增text-align,text-singleline,text-wordbreak,text-noclip,text-valign